### PR TITLE
Small fix to Session 5, Ex. 1

### DIFF
--- a/session5/session5.ipynb
+++ b/session5/session5.ipynb
@@ -85,7 +85,6 @@
     "sig = der + bytes([hash_type])\n",
     "sec = pk.point.sec()\n",
     "script_sig = bytes([len(sig)]) + sig + bytes([len(sec)]) + sec\n",
-    "script_sig = bytes([len(script_sig)]) + script_sig\n",
     "tx_obj.tx_ins[0].script_sig = Script.parse(script_sig)\n",
     "print(tx_obj.serialize().hex())"
    ]


### PR DESCRIPTION
In "Transaction Construction Example":

`script_sig = bytes([len(script_sig)]) + script_sig`

I believe the total length of scriptSig should not be inserted here. When `TxIn.serialize()` is returning the byte serialization of the transaction input, it does `encode_varint` of the scriptSig length there. If the scriptSig is constructed with the above line, you end up getting its length being inserted twice with the 2nd time being just a little bit longer.